### PR TITLE
Refresh dashboard and writeups presentation

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -4,21 +4,27 @@ import HeaderLink from "./HeaderLink.astro";
 ---
 
 <header>
-	<nav>
-		<h2><a href="/">{SITE_TITLE}</a></h2>
-		<div class="internal-links">
-			<HeaderLink href="/">Home</HeaderLink>
-			<HeaderLink href="/projects">Projects</HeaderLink>
-			<HeaderLink href="/writeups">Writeups</HeaderLink>
-			<HeaderLink href="/experience">Experience</HeaderLink>
-			<HeaderLink href="/blog">Blog</HeaderLink>
-			<HeaderLink href="/about">About</HeaderLink>
-		</div>
-		<div class="nav-actions">
-			<button class="theme-toggle" type="button" aria-label="Toggle color theme" aria-pressed="false" data-theme-toggle>
-				<svg class="icon-sun" viewBox="0 0 24 24" aria-hidden="true">
-					<path
-						fill="currentColor"
+        <div class="nav-wrapper">
+                <nav>
+                        <h2>
+                                <a href="/">
+                                        <span class="logo-pill"></span>
+                                        {SITE_TITLE}
+                                </a>
+                        </h2>
+                        <div class="internal-links">
+                                <HeaderLink href="/">Home</HeaderLink>
+                                <HeaderLink href="/projects">Projects</HeaderLink>
+                                <HeaderLink href="/writeups">Writeups</HeaderLink>
+                                <HeaderLink href="/experience">Experience</HeaderLink>
+                                <HeaderLink href="/blog">Blog</HeaderLink>
+                                <HeaderLink href="/about">About</HeaderLink>
+                        </div>
+                        <div class="nav-actions">
+                                <button class="theme-toggle" type="button" aria-label="Toggle color theme" aria-pressed="false" data-theme-toggle>
+                                        <svg class="icon-sun" viewBox="0 0 24 24" aria-hidden="true">
+                                                <path
+                                                        fill="currentColor"
 						d="M12 4.75a1 1 0 0 1-1-1V2a1 1 0 1 1 2 0v1.75a1 1 0 0 1-1 1zm0 14.5a1 1 0 0 1 1 1V22a1 1 0 0 1-2 0v-1.75a1 1 0 0 1 1-1zm7.25-7.25a1 1 0 0 1 1-1H22a1 1 0 1 1 0 2h-1.75a1 1 0 0 1-1-1zm-16.5 0a1 1 0 0 1 1-1H2a1 1 0 0 1 0 2h1.75a1 1 0 0 1-1-1zm12.038-5.788 1.238-1.238a1 1 0 1 1 1.414 1.414l-1.238 1.238a1 1 0 1 1-1.414-1.414zm-9.576 9.576 1.238-1.238a1 1 0 1 1 1.414 1.414l-1.238 1.238a1 1 0 0 1-1.414-1.414zm11.228 0a1 1 0 0 1 1.414 0l1.238 1.238a1 1 0 0 1-1.414 1.414l-1.238-1.238a1 1 0 0 1 0-1.414zm-9.576-9.576a1 1 0 0 1 0-1.414L6.1 4.314a1 1 0 1 1 1.414-1.414L8.752 4.14a1 1 0 0 1-1.414 1.414zM12 8a4 4 0 1 1 0 8 4 4 0 0 1 0-8z"
 					/>
 				</svg>
@@ -28,116 +34,178 @@ import HeaderLink from "./HeaderLink.astro";
 						d="M21 12.79A9 9 0 0 1 11.21 3a7 7 0 1 0 9.79 9.79z"
 					/>
 				</svg>
-			</button>
-			<div class="social-links">
-				<a href="https://www.linkedin.com" target="_blank">
-					<span class="sr-only">Connect on LinkedIn</span>
-					<svg viewBox="0 0 16 16" aria-hidden="true" width="32" height="32">
-						<path
-							fill="currentColor"
+                                </button>
+                                <div class="social-links">
+                                        <a href="https://www.linkedin.com" target="_blank">
+                                                <span class="sr-only">Connect on LinkedIn</span>
+                                                <svg viewBox="0 0 16 16" aria-hidden="true" width="32" height="32">
+                                                <path
+                                                        fill="currentColor"
 							d="M1.146 5.169H3.72v9.583H1.146zm1.286-4.7A1.566 1.566 0 0 1 4 .033c.433.21.779.71.73 1.196a1.562 1.562 0 0 1-3.123-.152c0-.418.262-.873.825-1.007zM5.176 5.169h2.44v1.31h.034c.34-.645 1.173-1.323 2.414-1.323 2.58 0 3.056 1.73 3.056 3.978v5.618h-2.573V9.84c0-1.065-.02-2.432-1.483-2.432-1.485 0-1.712 1.16-1.712 2.356v5.009H5.176z" />
-					</svg>
-				</a>
-				<a href="https://github.com" target="_blank">
-					<span class="sr-only">Explore GitHub projects</span>
-					<svg viewBox="0 0 16 16" aria-hidden="true" width="32" height="32">
+                                                </svg>
+                                        </a>
+                                        <a href="https://github.com" target="_blank">
+                                                <span class="sr-only">Explore GitHub projects</span>
+                                                <svg viewBox="0 0 16 16" aria-hidden="true" width="32" height="32">
 						<path
 							fill="currentColor"
 							d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1 .16 1.82.08 2.02.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.012 8.012 0 0 0 16 8c0-4.42-3.58-8-8-8z" />
-					</svg>
-				</a>
-				<a href="https://app.hackthebox.com" target="_blank">
-					<span class="sr-only">View Hack The Box profile</span>
-					<svg viewBox="0 0 24 24" aria-hidden="true" width="32" height="32">
+                                                </svg>
+                                        </a>
+                                        <a href="https://app.hackthebox.com" target="_blank">
+                                                <span class="sr-only">View Hack The Box profile</span>
+                                                <svg viewBox="0 0 24 24" aria-hidden="true" width="32" height="32">
 						<path fill="currentColor" d="M12 2 2 7v10l10 5 10-5V7zm0 2.236 6.764 3.382L12 11l-6.764-3.382zm-8 5.09L11 12.95v6.814L4 17.137zm9 6.815V12.95l7-3.624v7.137z" />
-					</svg>
-				</a>
-			</div>
-		</div>
-	</nav>
+                                                </svg>
+                                        </a>
+                                </div>
+                        </div>
+                </nav>
+        </div>
 </header>
 <style>
-	header {
-		margin: 0;
-		padding: 0 1.25em;
-		background: rgb(var(--surface-rgb));
-		box-shadow: var(--box-shadow);
-		backdrop-filter: blur(6px);
-		position: sticky;
-		top: 0;
-		z-index: 50;
-	}
-	h2 {
-		margin: 0;
-		font-size: 1.05em;
-		letter-spacing: 0.02em;
-	}
+        header {
+                margin: 0;
+                padding: 0 1.25em;
+                position: sticky;
+                top: 0;
+                z-index: 50;
+                backdrop-filter: blur(10px);
+                overflow: hidden;
+                isolation: isolate;
+        }
+        header::before {
+                content: "";
+                position: absolute;
+                inset: 0;
+                background: linear-gradient(120deg, rgba(109, 40, 217, 0.28), rgba(14, 165, 233, 0.35), rgba(16, 185, 129, 0.32));
+                opacity: 0.95;
+                z-index: -2;
+                animation: headerGlow 18s ease-in-out infinite;
+                pointer-events: none;
+        }
+        header::after {
+                content: "";
+                position: absolute;
+                inset: 0;
+                background: rgba(var(--surface-rgb), 0.8);
+                backdrop-filter: blur(16px);
+                z-index: -1;
+                pointer-events: none;
+        }
+        .nav-wrapper {
+                max-width: min(1180px, 100%);
+                margin: 0 auto;
+                padding: 0.35rem 0;
+        }
+        h2 {
+                margin: 0;
+                font-size: 1.15em;
+                letter-spacing: 0.04em;
+                text-transform: uppercase;
+                display: flex;
+        }
 
-	h2 a,
-	h2 a.active {
-		text-decoration: none;
-		color: rgb(var(--black));
-	}
-	nav {
-		display: flex;
-		align-items: center;
-		justify-content: space-between;
-		gap: 1.5rem;
-	}
-	.internal-links {
-		display: flex;
-		flex-wrap: wrap;
-		gap: 0.5rem;
-	}
-	nav a {
-		padding: 1em 0.5em;
-		color: rgb(var(--black));
-		border-bottom: 3px solid transparent;
-		text-decoration: none;
-		border-radius: 0.5rem;
-		transition: color 0.2s ease, background-color 0.2s ease;
-	}
-	nav a:hover {
-		background: rgba(var(--gray-light), 0.4);
-	}
-	nav a.active {
-		text-decoration: none;
-		border-bottom-color: var(--accent);
-	}
-	.nav-actions {
-		display: flex;
-		align-items: center;
-		gap: 1rem;
-	}
-	.theme-toggle {
-		display: inline-flex;
-		align-items: center;
-		justify-content: center;
+        h2 a,
+        h2 a.active {
+                text-decoration: none;
+                color: rgb(var(--black));
+                display: inline-flex;
+                align-items: center;
+                gap: 0.55rem;
+                padding: 0.35rem 0.75rem;
+                border-radius: 999px;
+                background: rgba(var(--surface-rgb), 0.6);
+                box-shadow: inset 0 0 0 1px rgba(var(--black), 0.08);
+                position: relative;
+                overflow: hidden;
+        }
+        h2 a::after {
+                content: "";
+                position: absolute;
+                inset: 0;
+                background: linear-gradient(120deg, rgba(56, 189, 248, 0.35), rgba(16, 185, 129, 0.3));
+                opacity: 0;
+                transition: opacity 0.3s ease;
+        }
+        h2 a:hover::after {
+                opacity: 1;
+        }
+        .logo-pill {
+                width: 0.65rem;
+                height: 2.1rem;
+                border-radius: 999px;
+                background: linear-gradient(180deg, rgba(129, 140, 248, 0.9), rgba(45, 212, 191, 0.9));
+                box-shadow: 0 0 18px rgba(59, 130, 246, 0.55);
+                animation: pulse 6s ease-in-out infinite;
+        }
+        nav {
+                display: flex;
+                align-items: center;
+                justify-content: space-between;
+                gap: 1.5rem;
+        }
+        .internal-links {
+                display: flex;
+                flex-wrap: wrap;
+                gap: 0.5rem;
+                justify-content: center;
+                position: relative;
+        }
+        nav a {
+                padding: 1em 0.5em;
+                color: rgb(var(--black));
+                border-bottom: 3px solid transparent;
+                text-decoration: none;
+                border-radius: 0.75rem;
+                transition: color 0.25s ease, background-color 0.25s ease, transform 0.25s ease;
+                position: relative;
+        }
+        nav a:hover {
+                background: rgba(var(--accent), 0.12);
+                transform: translateY(-2px);
+        }
+        nav a.active {
+                text-decoration: none;
+                border-bottom-color: var(--accent);
+                background: rgba(var(--accent), 0.15);
+        }
+        .nav-actions {
+                display: flex;
+                align-items: center;
+                gap: 1rem;
+        }
+        .theme-toggle {
+                display: inline-flex;
+                align-items: center;
+                justify-content: center;
 		gap: 0.35rem;
-		padding: 0.5rem 0.75rem;
-		border-radius: 999px;
-		background: rgba(var(--gray-light), 0.45);
-		border: 1px solid rgba(var(--gray), 0.3);
-		color: rgb(var(--black));
-		cursor: pointer;
-		font-weight: 600;
-		transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
-	}
-	.theme-toggle:hover {
-		background: rgba(var(--accent), 0.15);
-		border-color: rgba(var(--accent), 0.3);
-	}
-	.theme-toggle .icon-moon {
-		display: none;
-	}
-	html[data-theme="dark"] .theme-toggle {
-		background: rgba(var(--gray-light), 0.25);
-		border-color: rgba(var(--gray), 0.2);
-		color: rgb(var(--gray-dark));
-	}
-	html[data-theme="dark"] .theme-toggle .icon-sun {
-		display: none;
-	}
+                padding: 0.5rem 0.85rem;
+                border-radius: 999px;
+                background: rgba(255, 255, 255, 0.55);
+                border: 1px solid rgba(var(--gray), 0.25);
+                color: rgb(var(--black));
+                cursor: pointer;
+                font-weight: 600;
+                transition: background-color 0.25s ease, color 0.25s ease, border-color 0.25s ease, transform 0.25s ease;
+                box-shadow: 0 10px 22px rgba(15, 23, 42, 0.08);
+        }
+        .theme-toggle:hover {
+                background: rgba(var(--accent), 0.2);
+                border-color: rgba(var(--accent), 0.4);
+                transform: translateY(-2px);
+        }
+        .theme-toggle .icon-moon {
+                display: none;
+        }
+        html[data-theme="dark"] .theme-toggle {
+                background: rgba(var(--gray-light), 0.2);
+                border-color: rgba(var(--gray), 0.3);
+                color: rgb(var(--gray-dark));
+        }
+        html[data-theme="dark"] .theme-toggle .icon-sun {
+                display: none;
+        }
 	html[data-theme="dark"] .theme-toggle .icon-moon {
 		display: block;
 	}
@@ -154,41 +222,68 @@ import HeaderLink from "./HeaderLink.astro";
 		display: flex;
 	}
 	.social-links {
-		gap: 0.5rem;
-	}
-	.social-links a {
-		align-items: center;
-		justify-content: center;
-		color: rgb(var(--black));
-		border-radius: 999px;
-		padding: 0.35rem;
-		transition: background-color 0.2s ease;
-	}
-	.social-links a:hover {
-		background: rgba(var(--gray-light), 0.4);
-	}
-	@media (max-width: 960px) {
-		nav {
-			flex-direction: column;
-			align-items: stretch;
-		}
-		.internal-links {
-			justify-content: center;
-		}
-		.nav-actions {
-			width: 100%;
-			justify-content: center;
-			flex-wrap: wrap;
-		}
-		.social-links {
-			justify-content: center;
-		}
-	}
-	@media (max-width: 720px) {
-		.social-links {
-			display: none;
-		}
-	}
+                gap: 0.5rem;
+        }
+        .social-links a {
+                align-items: center;
+                justify-content: center;
+                color: rgb(var(--black));
+                border-radius: 999px;
+                padding: 0.35rem;
+                background: rgba(255, 255, 255, 0.5);
+                box-shadow: inset 0 0 0 1px rgba(var(--black), 0.05);
+                transition: background-color 0.2s ease, transform 0.25s ease;
+        }
+        .social-links a:hover {
+                background: rgba(var(--accent), 0.2);
+                transform: translateY(-2px);
+        }
+        @keyframes pulse {
+                0%,
+                100% {
+                        transform: scaleY(1);
+                        filter: drop-shadow(0 0 12px rgba(79, 70, 229, 0.4));
+                }
+                50% {
+                        transform: scaleY(1.15);
+                        filter: drop-shadow(0 0 22px rgba(34, 211, 238, 0.55));
+                }
+        }
+        @keyframes headerGlow {
+                0% {
+                        transform: translate3d(-5%, -5%, 0) scale(1.05);
+                }
+                50% {
+                        transform: translate3d(6%, 4%, 0) scale(1.1);
+                }
+                100% {
+                        transform: translate3d(-5%, -5%, 0) scale(1.05);
+                }
+        }
+        @media (max-width: 960px) {
+                nav {
+                        flex-direction: column;
+                        align-items: stretch;
+                        gap: 1.25rem;
+                }
+                .internal-links {
+                        justify-content: center;
+                }
+                .nav-actions {
+                        width: 100%;
+                        justify-content: center;
+                        flex-wrap: wrap;
+                        gap: 0.85rem;
+                }
+                .social-links {
+                        justify-content: center;
+                }
+        }
+        @media (max-width: 720px) {
+                .social-links {
+                        display: none;
+                }
+        }
 </style>
 
 <script is:inline>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -12,20 +12,27 @@ import { SITE_DESCRIPTION, SITE_TITLE } from '../consts';
 	</head>
 	<body>
 		<Header />
-		<main>
-			<section class="hero">
-				<p class="eyebrow">Cybersecurity Specialist - Offensive Security - Blue Team Ally</p>
-				<h1>Strengthening defenses through hands-on security research.</h1>
-				<p class="lede">
-					I help organizations understand how attackers think, harden their infrastructure, and respond to
-					real incidents. Explore my project work, incident writeups, and experience to see how I turn
-					curiosity into resilient security outcomes.
-				</p>
-				<div class="hero-actions">
-					<a class="cta" href="/projects">View Projects</a>
-					<a class="ghost" href="/writeups">Read Writeups</a>
-				</div>
-			</section>
+                <main>
+                        <section class="hero">
+                                <div class="hero-content">
+                                        <p class="eyebrow">Cybersecurity Specialist - Offensive Security - Blue Team Ally</p>
+                                        <h1>Strengthening defenses through hands-on security research.</h1>
+                                        <p class="lede">
+                                                I help organizations understand how attackers think, harden their infrastructure, and respond to
+                                                real incidents. Explore my project work, incident writeups, and experience to see how I turn
+                                                curiosity into resilient security outcomes.
+                                        </p>
+                                        <div class="hero-actions">
+                                                <a class="cta" href="/projects">View Projects</a>
+                                                <a class="ghost" href="/writeups">Read Writeups</a>
+                                        </div>
+                                </div>
+                                <div class="hero-visual" aria-hidden="true">
+                                        <div class="orb orb-primary"></div>
+                                        <div class="orb orb-secondary"></div>
+                                        <div class="grid-overlay"></div>
+                                </div>
+                        </section>
 
 			<section class="pillars">
 				<h2>Focus Areas</h2>
@@ -77,89 +84,237 @@ import { SITE_DESCRIPTION, SITE_TITLE } from '../consts';
 </html>
 
 <style>
-	main {
-		max-width: 960px;
-		margin: 0 auto;
-		padding: 3rem 1.5rem 4rem;
-		color: var(--black);
+        main {
+                max-width: min(1220px, 100%);
+                margin: 0 auto;
+                padding: 4rem 1.5rem 5rem;
+                color: var(--black);
+        }
+        section {
+                margin-bottom: 3rem;
+        }
+        .hero {
+                display: grid;
+                gap: 2.5rem;
+                grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+                align-items: center;
+                background: radial-gradient(circle at top left, rgba(129, 140, 248, 0.25), transparent 55%),
+                        radial-gradient(circle at bottom right, rgba(45, 212, 191, 0.2), transparent 50%),
+                        rgba(var(--surface-rgb), 0.82);
+                padding: clamp(2.5rem, 4vw + 1rem, 4rem);
+                border-radius: 1.8rem;
+                position: relative;
+                overflow: hidden;
+                box-shadow: 0 40px 80px rgba(15, 23, 42, 0.12);
+                isolation: isolate;
+        }
+        .hero::after {
+                content: "";
+                position: absolute;
+                inset: 0;
+                background: linear-gradient(120deg, rgba(56, 189, 248, 0.12), rgba(34, 197, 94, 0.12));
+                opacity: 0;
+                transition: opacity 0.6s ease;
+                z-index: -1;
+        }
+        .hero:hover::after {
+                opacity: 1;
+        }
+        .hero-content {
+                display: grid;
+                gap: 1.5rem;
+        }
+        .eyebrow {
+                letter-spacing: 0.12em;
+                text-transform: uppercase;
+                font-size: 0.85rem;
+                color: var(--accent);
+                font-weight: 600;
+                background: rgba(var(--accent), 0.18);
+                display: inline-flex;
+                align-items: center;
+                justify-content: center;
+                padding: 0.45rem 0.9rem;
+                border-radius: 999px;
+                width: fit-content;
+        }
+        .lede {
+                font-size: 1.15rem;
+                line-height: 1.7;
+                max-width: 60ch;
 	}
-	section {
-		margin-bottom: 3rem;
-	}
-	.hero {
-		display: grid;
-		gap: 1.5rem;
-	}
-	.eyebrow {
-		letter-spacing: 0.12em;
-		text-transform: uppercase;
-		font-size: 0.85rem;
-		color: var(--accent);
-		font-weight: 600;
-	}
-	.lede {
-		font-size: 1.15rem;
-		line-height: 1.7;
-		max-width: 60ch;
-	}
-	.hero-actions {
-		display: flex;
-		gap: 1rem;
-		flex-wrap: wrap;
-	}
-	.cta,
-	.ghost {
-		display: inline-flex;
-		align-items: center;
+        .hero-actions {
+                display: flex;
+                gap: 1rem;
+                flex-wrap: wrap;
+                align-items: center;
+        }
+        .cta,
+        .ghost {
+                display: inline-flex;
+                align-items: center;
 		justify-content: center;
 		padding: 0.75rem 1.5rem;
 		border-radius: 999px;
 		font-weight: 600;
 		text-decoration: none;
 	}
-	.cta {
-		background: var(--accent);
-		color: white;
-	}
-	.ghost {
-		border: 2px solid var(--accent);
-		color: var(--accent);
-	}
-	.pillars .grid {
-		display: grid;
-		gap: 1.5rem;
-		grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-	}
-	.pillars article {
-		padding: 1.5rem;
-		border: 1px solid rgba(var(--black), 0.08);
-		border-radius: 1rem;
-		box-shadow: 0 8px 24px rgba(var(--black), 0.06);
-	}
-	.highlights ul {
-		list-style: none;
-		padding: 0;
-		display: grid;
-		gap: 1rem;
-	}
-	.highlights li {
-		background: rgba(var(--accent), 0.08);
-		padding: 1rem 1.25rem;
-		border-radius: 0.75rem;
-	}
-	.next {
-		text-align: center;
-		padding: 2rem;
-		border: 1px solid rgba(var(--black), 0.08);
-		border-radius: 1rem;
-		box-shadow: 0 8px 24px rgba(var(--black), 0.05);
-	}
-	.next p {
-		margin-bottom: 1.5rem;
-	}
-	@media (max-width: 720px) {
-		main {
-			padding: 2.5rem 1rem 3rem;
-		}
-	}
+        .cta {
+                background: var(--accent);
+                color: white;
+                box-shadow: 0 24px 48px rgba(16, 185, 129, 0.35);
+                transition: transform 0.3s ease, box-shadow 0.3s ease;
+        }
+        .ghost {
+                border: 2px solid var(--accent);
+                color: var(--accent);
+                transition: transform 0.3s ease, border-color 0.3s ease, color 0.3s ease;
+        }
+        .cta:hover,
+        .ghost:hover {
+                transform: translateY(-3px);
+        }
+        .cta:hover {
+                box-shadow: 0 28px 62px rgba(16, 185, 129, 0.45);
+        }
+        .ghost:hover {
+                color: rgb(20, 83, 45);
+                border-color: rgb(16, 185, 129);
+        }
+        .hero-visual {
+                position: relative;
+                min-height: 240px;
+        }
+        .orb {
+                position: absolute;
+                border-radius: 50%;
+                filter: blur(0px);
+                opacity: 0.75;
+                animation: float 12s ease-in-out infinite;
+                mix-blend-mode: screen;
+        }
+        .orb-primary {
+                width: 240px;
+                height: 240px;
+                top: 10%;
+                left: 12%;
+                background: radial-gradient(circle, rgba(129, 140, 248, 0.85), rgba(79, 70, 229, 0));
+                animation-delay: 0s;
+        }
+        .orb-secondary {
+                width: 180px;
+                height: 180px;
+                bottom: 10%;
+                right: 5%;
+                background: radial-gradient(circle, rgba(16, 185, 129, 0.85), rgba(16, 185, 129, 0));
+                animation-delay: -4s;
+        }
+        .grid-overlay {
+                position: absolute;
+                inset: 8%;
+                border-radius: 1.5rem;
+                background-image: linear-gradient(rgba(148, 163, 184, 0.12) 1px, transparent 1px),
+                        linear-gradient(90deg, rgba(148, 163, 184, 0.12) 1px, transparent 1px);
+                background-size: 22px 22px;
+                mask: radial-gradient(circle at center, rgba(255, 255, 255, 0.65), rgba(255, 255, 255, 0) 70%);
+                animation: heroGridDrift 18s linear infinite;
+        }
+        @keyframes heroGridDrift {
+                0% {
+                        transform: translate3d(0, 0, 0) rotate(0deg);
+                }
+                50% {
+                        transform: translate3d(12px, -10px, 0) rotate(2deg);
+                }
+                100% {
+                        transform: translate3d(0, 0, 0) rotate(0deg);
+                }
+        }
+        @keyframes float {
+                0%,
+                100% {
+                        transform: translate3d(0, 0, 0) scale(1);
+                }
+                50% {
+                        transform: translate3d(16px, -14px, 0) scale(1.08);
+                }
+        }
+        .pillars .grid {
+                display: grid;
+                gap: 1.5rem;
+                grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+        }
+        .pillars article {
+                padding: 1.5rem;
+                border: 1px solid rgba(var(--black), 0.08);
+                border-radius: 1rem;
+                box-shadow: 0 16px 32px rgba(var(--black), 0.08);
+                background: rgba(255, 255, 255, 0.86);
+                position: relative;
+                overflow: hidden;
+                transition: transform 0.3s ease, box-shadow 0.3s ease;
+        }
+        .pillars article::before {
+                content: "";
+                position: absolute;
+                inset: 0;
+                background: linear-gradient(135deg, rgba(129, 140, 248, 0.08), rgba(16, 185, 129, 0.08));
+                opacity: 0;
+                transition: opacity 0.3s ease;
+        }
+        .pillars article:hover {
+                transform: translateY(-6px);
+                box-shadow: 0 28px 48px rgba(15, 23, 42, 0.15);
+        }
+        .pillars article:hover::before {
+                opacity: 1;
+        }
+        .highlights ul {
+                list-style: none;
+                padding: 0;
+                display: grid;
+                gap: 1.25rem;
+        }
+        .highlights li {
+                background: linear-gradient(90deg, rgba(16, 185, 129, 0.12), rgba(59, 130, 246, 0.12));
+                padding: 1.1rem 1.45rem;
+                border-radius: 1rem;
+                border: 1px solid rgba(var(--accent), 0.15);
+                box-shadow: 0 18px 30px rgba(15, 23, 42, 0.08);
+                transition: transform 0.3s ease, box-shadow 0.3s ease;
+        }
+        .highlights li:hover {
+                transform: translateX(6px);
+                box-shadow: 0 24px 40px rgba(15, 23, 42, 0.14);
+        }
+        .next {
+                text-align: center;
+                padding: clamp(2rem, 4vw, 2.75rem);
+                border: 1px solid rgba(var(--black), 0.08);
+                border-radius: 1.3rem;
+                box-shadow: 0 20px 40px rgba(var(--black), 0.07);
+                background: rgba(255, 255, 255, 0.92);
+                position: relative;
+                overflow: hidden;
+        }
+        .next p {
+                margin-bottom: 1.5rem;
+        }
+        .next::before {
+                content: "";
+                position: absolute;
+                inset: -40% -20% auto;
+                height: 60%;
+                background: radial-gradient(circle, rgba(16, 185, 129, 0.2), transparent 70%);
+                animation: float 16s ease-in-out infinite;
+                opacity: 0.7;
+        }
+        @media (max-width: 720px) {
+                main {
+                        padding: 3rem 1rem 3.5rem;
+                }
+                .hero {
+                        padding: 2.5rem;
+                }
+        }
 </style>

--- a/src/pages/writeups/index.astro
+++ b/src/pages/writeups/index.astro
@@ -41,108 +41,180 @@ const pageTitle = "Writeups | " + SITE_TITLE;
 	</head>
 	<body>
 		<Header />
-		<main>
-			<header class="page-header">
-				<h1>Writeups</h1>
-				<p>
-					Every investigation note is written in Markdown and lives inside <code>src/content/writeups</code>.
-					Drop screenshots beneath <code>public/images/writeups/&lt;slug&gt;/</code> and reference them right
-					inside the Markdown body.
-				</p>
-			</header>
+                <main>
+                        <header class="page-header">
+                                <div class="page-heading">
+                                        <span class="eyebrow">Investigation Library</span>
+                                        <h1>Writeups</h1>
+                                </div>
+                                <p>
+                                        Every investigation note is written in Markdown and lives inside <code>src/content/writeups</code>.
+                                        Drop screenshots beneath <code>public/images/writeups/&lt;slug&gt;/</code> and reference them right
+                                        inside the Markdown body.
+                                </p>
+                        </header>
 
-			<section class="grid">
-				{writeups.map((entry) => (
-					<article class="card">
-						<a class="card-link" href={`/writeups/${entry.slug}/`}>
-							{entry.heroImage && (
-								<img class="hero" src={entry.heroImage} alt={entry.title} loading="lazy" />
-							)}
-							<div class="meta">
-								<p class="posted">{entry.pubDate.toLocaleDateString()}</p>
-								<h2>{entry.title}</h2>
-								<p class="summary">{entry.summary}</p>
-								{entry.tools.length > 0 && (
-									<ul class="tools" aria-label="Tooling">
-										{entry.tools.map((tool) => (
-											<li>{tool}</li>
-										))}
-									</ul>
-								)}
-								{entry.tags.length > 0 && (
-									<ul class="tags" aria-label="Tags">
-										{entry.tags.map((tag) => (
-											<li>{tag}</li>
-										))}
-									</ul>
-								)}
-							</div>
-						</a>
-					</article>
-				))}
-			</section>
-		</main>
+                        <section class="grid">
+                                {writeups.map((entry) => (
+                                        <article class="card">
+                                                <a class="card-link" href={`/writeups/${entry.slug}/`}>
+                                                        <div class="card-sheen" aria-hidden="true"></div>
+                                                        {entry.heroImage && (
+                                                                <img class="hero" src={entry.heroImage} alt={entry.title} loading="lazy" />
+                                                        )}
+                                                        <div class="meta">
+                                                                <div class="meta-top">
+                                                                        <p class="posted">{entry.pubDate.toLocaleDateString()}</p>
+                                                                        {entry.updatedDate && (
+                                                                                <p class="updated">Updated {entry.updatedDate.toLocaleDateString()}</p>
+                                                                        )}
+                                                                </div>
+                                                                <h2>{entry.title}</h2>
+                                                                <p class="summary">{entry.summary}</p>
+                                                                {entry.tools.length > 0 && (
+                                                                        <ul class="tools" aria-label="Tooling">
+                                                                                {entry.tools.map((tool) => (
+                                                                                        <li>{tool}</li>
+                                                                                ))}
+                                                                        </ul>
+                                                                )}
+                                                                {entry.tags.length > 0 && (
+                                                                        <ul class="tags" aria-label="Tags">
+                                                                                {entry.tags.map((tag) => (
+                                                                                        <li>{tag}</li>
+                                                                                ))}
+                                                                        </ul>
+                                                                )}
+                                                        </div>
+                                                </a>
+                                        </article>
+                                ))}
+                        </section>
+                </main>
 		<Footer />
 	</body>
 </html>
 
 <style>
-	main {
-		max-width: 1060px;
-		margin: 0 auto;
-		padding: 3rem 1.5rem 5rem;
-	}
-	.page-header {
-		margin-bottom: 2.5rem;
-	}
-	.page-header p {
-		max-width: 70ch;
-	}
-	.grid {
-		display: grid;
-		gap: 2rem;
-		grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
-	}
-	.card {
-		background: rgb(var(--surface-rgb));
-		border-radius: 1.1rem;
-		box-shadow: var(--box-shadow);
-		overflow: hidden;
-		transition: transform 0.2s ease, box-shadow 0.2s ease;
-	}
-	.card-link {
-		display: block;
-		text-decoration: none;
-		color: inherit;
-		height: 100%;
-	}
-	.card:hover {
-		transform: translateY(-6px);
-		box-shadow: 0 18px 34px rgba(15, 23, 42, 0.18);
-	}
-	.hero {
-		width: 100%;
-		height: auto;
-		object-fit: cover;
-	}
-	.meta {
-		padding: 1.75rem 1.5rem 1.5rem;
-		color: rgb(var(--gray-dark));
-		display: grid;
-		gap: 1rem;
-	}
-	.posted {
-		margin: 0;
-		font-size: 0.9rem;
-		letter-spacing: 0.08em;
-		text-transform: uppercase;
-		color: rgba(var(--gray), 0.8);
-	}
-	.summary {
-		margin: 0;
-		color: rgba(var(--gray-dark), 0.9);
-		line-height: 1.6;
-	}
+        main {
+                max-width: min(1220px, 100%);
+                margin: 0 auto;
+                padding: 4rem 1.5rem 5.5rem;
+        }
+        .page-header {
+                margin-bottom: 3.5rem;
+                display: grid;
+                gap: 1.25rem;
+                background: rgba(255, 255, 255, 0.85);
+                border-radius: 1.5rem;
+                padding: 2.25rem clamp(1.5rem, 4vw, 2.5rem);
+                box-shadow: 0 30px 60px rgba(15, 23, 42, 0.12);
+                position: relative;
+                overflow: hidden;
+                isolation: isolate;
+        }
+        .page-header::before {
+                content: "";
+                position: absolute;
+                inset: 0;
+                background: linear-gradient(120deg, rgba(14, 165, 233, 0.16), rgba(16, 185, 129, 0.18));
+                opacity: 0.7;
+                z-index: -2;
+                animation: headerRibbonDrift 22s ease-in-out infinite;
+        }
+        .page-header::after {
+                content: "";
+                position: absolute;
+                inset: 0;
+                background: rgba(255, 255, 255, 0.75);
+                z-index: -1;
+        }
+        .page-header p {
+                max-width: 70ch;
+                margin: 0;
+        }
+        .page-heading {
+                display: flex;
+                flex-wrap: wrap;
+                align-items: center;
+                gap: 1rem;
+        }
+        .page-heading h1 {
+                font-size: clamp(2.4rem, 4vw, 3rem);
+                margin: 0;
+        }
+        .eyebrow {
+                letter-spacing: 0.12em;
+                text-transform: uppercase;
+                font-size: 0.9rem;
+                background: rgba(var(--accent), 0.2);
+                color: rgb(var(--black));
+                padding: 0.4rem 0.8rem;
+                border-radius: 999px;
+                font-weight: 700;
+        }
+        .grid {
+                display: grid;
+                gap: 2.5rem;
+                grid-template-columns: repeat(auto-fit, minmax(340px, 1fr));
+        }
+        .card {
+                background: rgba(255, 255, 255, 0.9);
+                border-radius: 1.35rem;
+                box-shadow: 0 30px 60px rgba(15, 23, 42, 0.14);
+                overflow: hidden;
+                transition: transform 0.35s ease, box-shadow 0.35s ease;
+                position: relative;
+                isolation: isolate;
+        }
+        .card-link {
+                display: block;
+                text-decoration: none;
+                color: inherit;
+                height: 100%;
+                position: relative;
+        }
+        .card:hover {
+                transform: translateY(-10px);
+                box-shadow: 0 40px 70px rgba(15, 23, 42, 0.2);
+        }
+        .hero {
+                width: 100%;
+                height: auto;
+                object-fit: cover;
+                max-height: 220px;
+        }
+        .meta {
+                padding: 1.85rem 1.75rem 1.75rem;
+                color: rgb(var(--gray-dark));
+                display: grid;
+                gap: 1.1rem;
+        }
+        .posted {
+                margin: 0;
+                font-size: 0.9rem;
+                letter-spacing: 0.08em;
+                text-transform: uppercase;
+                color: rgba(var(--gray), 0.8);
+        }
+        .updated {
+                margin: 0;
+                font-size: 0.9rem;
+                color: rgba(var(--accent), 0.9);
+                font-weight: 600;
+        }
+        .meta-top {
+                display: flex;
+                flex-wrap: wrap;
+                justify-content: space-between;
+                gap: 0.75rem;
+                align-items: baseline;
+        }
+        .summary {
+                margin: 0;
+                color: rgba(var(--gray-dark), 0.9);
+                line-height: 1.6;
+        }
 	.tools,
 	.tags {
 		margin: 0;
@@ -161,13 +233,38 @@ const pageTitle = "Writeups | " + SITE_TITLE;
 		color: var(--accent);
 		font-weight: 600;
 	}
-	.tags li {
-		background: rgba(var(--gray-light), 0.45);
-		color: rgb(var(--gray-dark));
-	}
-	@media (max-width: 720px) {
-		main {
-			padding: 2.5rem 1rem 4rem;
-		}
-	}
+        .tags li {
+                background: rgba(var(--gray-light), 0.45);
+                color: rgb(var(--gray-dark));
+        }
+        .card-sheen {
+                position: absolute;
+                inset: 0;
+                background: linear-gradient(120deg, rgba(255, 255, 255, 0) 20%, rgba(255, 255, 255, 0.35) 50%, rgba(255, 255, 255, 0) 80%);
+                transform: translateX(-100%);
+                transition: transform 0.8s ease;
+                z-index: 1;
+        }
+        .card:hover .card-sheen {
+                transform: translateX(120%);
+        }
+        @keyframes headerRibbonDrift {
+                0% {
+                        transform: translate3d(-10px, -6px, 0) scale(1);
+                }
+                50% {
+                        transform: translate3d(12px, 8px, 0) scale(1.02);
+                }
+                100% {
+                        transform: translate3d(-10px, -6px, 0) scale(1);
+                }
+        }
+        @media (max-width: 720px) {
+                main {
+                        padding: 3rem 1rem 4.5rem;
+                }
+                .page-header {
+                        padding: 2rem 1.5rem;
+                }
+        }
 </style>


### PR DESCRIPTION
## Summary
- restyle the global header with an animated gradient shell, pill logo, and livelier interactions
- redesign the home dashboard hero and sections with wider layout, animated visuals, and refined hover treatments
- widen the writeups listing with a featured intro panel, refreshed cards, and animation accents

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68dfd9e4bbf8832db6f04ef0422a2ede