### PR TITLE
Improve surface theming for homepage cards

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -251,10 +251,10 @@ import { SITE_DESCRIPTION, SITE_TITLE } from '../consts';
         }
         .pillars article {
                 padding: 1.65rem;
-                border: 1px solid rgba(var(--black), 0.08);
+                border: 1px solid rgba(var(--black), 0.12);
                 border-radius: 1rem;
-                box-shadow: 0 16px 32px rgba(var(--black), 0.08);
-                background: rgba(255, 255, 255, 0.9);
+                box-shadow: 0 16px 32px rgba(var(--black), 0.12);
+                background: rgba(var(--surface-rgb), 0.96);
                 position: relative;
                 overflow: hidden;
                 transition: transform 0.3s ease, box-shadow 0.3s ease;
@@ -269,7 +269,7 @@ import { SITE_DESCRIPTION, SITE_TITLE } from '../consts';
         }
         .pillars article:hover {
                 transform: translateY(-6px);
-                box-shadow: 0 28px 48px rgba(15, 23, 42, 0.15);
+                box-shadow: 0 28px 48px rgba(var(--black), 0.18);
         }
         .pillars article:hover::before {
                 opacity: 1;
@@ -298,10 +298,10 @@ import { SITE_DESCRIPTION, SITE_TITLE } from '../consts';
         .next {
                 text-align: center;
                 padding: clamp(2rem, 4vw, 2.75rem);
-                border: 1px solid rgba(var(--black), 0.08);
+                border: 1px solid rgba(var(--black), 0.12);
                 border-radius: 1.3rem;
-                box-shadow: 0 20px 40px rgba(var(--black), 0.07);
-                background: rgba(255, 255, 255, 0.92);
+                box-shadow: 0 20px 40px rgba(var(--black), 0.12);
+                background: rgba(var(--surface-rgb), 0.96);
                 position: relative;
                 overflow: hidden;
         }
@@ -316,6 +316,26 @@ import { SITE_DESCRIPTION, SITE_TITLE } from '../consts';
                 background: radial-gradient(circle, rgba(16, 185, 129, 0.2), transparent 70%);
                 animation: float 16s ease-in-out infinite;
                 opacity: 0.7;
+        }
+        html[data-theme="dark"] .pillars article {
+                background: rgba(var(--surface-rgb), 0.9);
+                border-color: rgba(148, 163, 184, 0.18);
+                box-shadow: 0 16px 32px rgba(2, 6, 23, 0.65);
+        }
+        html[data-theme="dark"] .pillars article:hover {
+                box-shadow: 0 28px 48px rgba(2, 6, 23, 0.72);
+        }
+        html[data-theme="dark"] .pillars article::before {
+                background: linear-gradient(135deg, rgba(129, 140, 248, 0.16), rgba(16, 185, 129, 0.16));
+        }
+        html[data-theme="dark"] .next {
+                background: rgba(var(--surface-rgb), 0.9);
+                border-color: rgba(148, 163, 184, 0.18);
+                box-shadow: 0 20px 40px rgba(2, 6, 23, 0.62);
+        }
+        html[data-theme="dark"] .next::before {
+                background: radial-gradient(circle, rgba(59, 130, 246, 0.32), transparent 70%);
+                opacity: 0.85;
         }
         [data-animate] {
                 opacity: 0;


### PR DESCRIPTION
## Summary
- derive the Focus Areas cards and CTA backgrounds from the shared surface color token
- tune borders, shadows, and overlay treatments to stay legible across themes
- add dark theme adjustments for hover and accent overlays to preserve contrast

## Testing
- npm run dev -- --host 0.0.0.0 --port 4321 (manual verification in light and dark themes)


------
https://chatgpt.com/codex/tasks/task_b_68dfe092271c832db27aac61b955c0e4