### PR TITLE
Adjust header controls for theme-aware surfaces

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -179,11 +179,11 @@ import HeaderLink from "./HeaderLink.astro";
                 display: inline-flex;
                 align-items: center;
                 justify-content: center;
-		gap: 0.35rem;
+                gap: 0.35rem;
                 padding: 0.5rem 0.85rem;
                 border-radius: 999px;
-                background: rgba(255, 255, 255, 0.55);
-                border: 1px solid rgba(var(--gray), 0.25);
+                background: rgba(var(--surface-rgb), 0.72);
+                border: 1px solid rgba(var(--black), 0.08);
                 color: rgb(var(--black));
                 cursor: pointer;
                 font-weight: 600;
@@ -191,24 +191,38 @@ import HeaderLink from "./HeaderLink.astro";
                 box-shadow: 0 10px 22px rgba(15, 23, 42, 0.08);
         }
         .theme-toggle:hover {
-                background: rgba(var(--accent), 0.2);
-                border-color: rgba(var(--accent), 0.4);
+                background: rgba(var(--surface-rgb), 0.88);
+                border-color: rgba(var(--accent), 0.35);
                 transform: translateY(-2px);
+        }
+        .theme-toggle[aria-pressed="true"] {
+                background: rgba(var(--surface-rgb), 0.9);
+                box-shadow: 0 0 0 1px rgba(var(--accent), 0.18), 0 12px 26px rgba(15, 23, 42, 0.12);
         }
         .theme-toggle .icon-moon {
                 display: none;
         }
         html[data-theme="dark"] .theme-toggle {
-                background: rgba(var(--gray-light), 0.2);
-                border-color: rgba(var(--gray), 0.3);
+                background: rgba(var(--surface-rgb), 0.55);
+                border-color: rgba(var(--gray-light), 0.18);
                 color: rgb(var(--gray-dark));
+                box-shadow: 0 0 0 1px rgba(var(--gray-light), 0.08), 0 18px 32px rgba(2, 6, 23, 0.45);
         }
         html[data-theme="dark"] .theme-toggle .icon-sun {
                 display: none;
         }
-	html[data-theme="dark"] .theme-toggle .icon-moon {
-		display: block;
-	}
+        html[data-theme="dark"] .theme-toggle .icon-moon {
+                display: block;
+        }
+        html[data-theme="dark"] .theme-toggle:hover {
+                background: rgba(var(--surface-rgb), 0.65);
+                border-color: rgba(var(--accent), 0.35);
+                box-shadow: 0 0 0 1px rgba(var(--accent), 0.2), 0 20px 34px rgba(2, 6, 23, 0.55);
+        }
+        html[data-theme="dark"] .theme-toggle[aria-pressed="true"] {
+                background: rgba(var(--surface-rgb), 0.62);
+                box-shadow: 0 0 0 1px rgba(var(--accent), 0.22), 0 22px 36px rgba(2, 6, 23, 0.6);
+        }
 	.theme-toggle svg {
 		width: 1.1rem;
 		height: 1.1rem;
@@ -230,13 +244,25 @@ import HeaderLink from "./HeaderLink.astro";
                 color: rgb(var(--black));
                 border-radius: 999px;
                 padding: 0.35rem;
-                background: rgba(255, 255, 255, 0.5);
-                box-shadow: inset 0 0 0 1px rgba(var(--black), 0.05);
+                background: rgba(var(--surface-rgb), 0.65);
+                box-shadow: inset 0 0 0 1px rgba(var(--black), 0.05), 0 8px 16px rgba(15, 23, 42, 0.08);
                 transition: background-color 0.2s ease, transform 0.25s ease;
         }
         .social-links a:hover {
-                background: rgba(var(--accent), 0.2);
+                background: rgba(var(--surface-rgb), 0.82);
                 transform: translateY(-2px);
+        }
+        .social-links a:focus-visible {
+                outline: 3px solid rgba(var(--accent), 0.45);
+                outline-offset: 2px;
+        }
+        html[data-theme="dark"] .social-links a {
+                color: rgb(var(--gray-dark));
+                background: rgba(var(--surface-rgb), 0.55);
+                box-shadow: inset 0 0 0 1px rgba(var(--gray-light), 0.15), 0 12px 20px rgba(2, 6, 23, 0.5);
+        }
+        html[data-theme="dark"] .social-links a:hover {
+                background: rgba(var(--surface-rgb), 0.65);
         }
         @keyframes pulse {
                 0%,


### PR DESCRIPTION
## Summary
- update the header theme toggle and social icons to draw surfaces from the theme palette instead of fixed white fills
- refine dark theme states with softer borders and shadows so controls stay legible without glowing
- tweak pressed and hover treatments to keep the toggle state clear across themes

## Testing
- not run (CSS-only changes)

------
https://chatgpt.com/codex/tasks/task_b_68dfe09a178c832d8948b647d739f0ee