### PR TITLE
Revitalize focus area and writeups sections

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -34,25 +34,40 @@ import { SITE_DESCRIPTION, SITE_TITLE } from '../consts';
                                 </div>
                         </section>
 
-                        <section class="pillars" data-animate="stagger">
+                        <section class="pillars" data-animate>
                                 <h2>Focus Areas</h2>
-                                <div class="grid">
-                                        <article>
-                                                <h3>Adversary Emulation</h3>
+                                <div class="pillars-grid" data-animate="stagger">
+                                        <article class="pillar-card pillar-card--adversary">
+                                                <span class="pillar-card__glow" aria-hidden="true"></span>
+                                                <span class="pillar-card__pulse" aria-hidden="true"></span>
+                                                <header>
+                                                        <h3>Adversary Emulation</h3>
+                                                        <p class="pillar-subhead">Offensive testing that exposes blind spots before real attackers can.</p>
+                                                </header>
                                                 <p>
-                                                        Red team assessments, exploit development, and detection engineering that mirror real threat
-                                                        actors to expose blind spots before attackers do.
+                                                        Red team assessments, exploit development, and detection engineering that mirror real threat actors
+                                                        to expose blind spots before attackers do.
                                                 </p>
                                         </article>
-                                        <article>
-                                                <h3>Threat Detection &amp; Response</h3>
+                                        <article class="pillar-card pillar-card--detect">
+                                                <span class="pillar-card__glow" aria-hidden="true"></span>
+                                                <span class="pillar-card__pulse" aria-hidden="true"></span>
+                                                <header>
+                                                        <h3>Threat Detection &amp; Response</h3>
+                                                        <p class="pillar-subhead">Automation and playbooks that keep blue teams decisive.</p>
+                                                </header>
                                                 <p>
                                                         Playbooks, SIEM tuning, and automation that help blue teams react fast and contain incidents with
                                                         confidence.
                                                 </p>
                                         </article>
-                                        <article>
-                                                <h3>Security Education</h3>
+                                        <article class="pillar-card pillar-card--educate">
+                                                <span class="pillar-card__glow" aria-hidden="true"></span>
+                                                <span class="pillar-card__pulse" aria-hidden="true"></span>
+                                                <header>
+                                                        <h3>Security Education</h3>
+                                                        <p class="pillar-subhead">Making complex exploits approachable for every stakeholder.</p>
+                                                </header>
                                                 <p>
                                                         Workshops, capture-the-flag mentoring, and public writeups that make complex vulnerabilities
                                                         accessible to engineers and executives alike.
@@ -244,38 +259,115 @@ import { SITE_DESCRIPTION, SITE_TITLE } from '../consts';
                         transform: translate3d(16px, -14px, 0) scale(1.08);
                 }
         }
-        .pillars .grid {
+        .pillars-grid {
                 display: grid;
-                gap: clamp(1.5rem, 3vw, 2rem);
+                gap: clamp(1.5rem, 3vw, 2.1rem);
                 grid-template-columns: repeat(auto-fit, minmax(clamp(240px, 28vw, 340px), 1fr));
         }
-        .pillars article {
-                padding: 1.65rem;
-                border: 1px solid rgba(var(--black), 0.12);
-                border-radius: 1rem;
-                box-shadow: 0 16px 32px rgba(var(--black), 0.12);
-                background: rgba(var(--surface-rgb), 0.96);
+        .pillar-card {
+                --pillar-primary: 129, 140, 248;
+                --pillar-secondary: 56, 189, 248;
                 position: relative;
+                padding: clamp(1.75rem, 4vw, 2.25rem);
+                border-radius: 1.25rem;
+                background: linear-gradient(135deg, rgba(var(--pillar-primary), 0.16), rgba(var(--pillar-secondary), 0.12));
+                border: 1px solid rgba(var(--pillar-primary), 0.18);
+                box-shadow: 0 22px 44px rgba(15, 23, 42, 0.18);
                 overflow: hidden;
-                transition: transform 0.3s ease, box-shadow 0.3s ease;
+                transition: transform 0.35s ease, box-shadow 0.35s ease, border-color 0.35s ease;
         }
-        .pillars article::before {
-                content: "";
+        .pillar-card header {
+                display: grid;
+                gap: 0.45rem;
+                margin-bottom: 0.75rem;
+        }
+        .pillar-card h3 {
+                margin: 0;
+        }
+        .pillar-subhead {
+                margin: 0;
+                font-size: 0.95rem;
+                letter-spacing: 0.04em;
+                text-transform: uppercase;
+                color: rgba(var(--pillar-primary), 0.9);
+                font-weight: 700;
+        }
+        .pillar-card p {
+                position: relative;
+                z-index: 1;
+                margin: 0;
+                line-height: 1.65;
+                color: rgba(15, 23, 42, 0.78);
+        }
+        .pillar-card__glow,
+        .pillar-card__pulse {
                 position: absolute;
                 inset: 0;
-                background: linear-gradient(135deg, rgba(129, 140, 248, 0.08), rgba(16, 185, 129, 0.08));
+                border-radius: inherit;
+                pointer-events: none;
+        }
+        .pillar-card__glow {
+                background: radial-gradient(circle at top right, rgba(var(--pillar-secondary), 0.4), transparent 60%),
+                        radial-gradient(circle at bottom left, rgba(var(--pillar-primary), 0.35), transparent 55%);
+                opacity: 0.85;
+                mix-blend-mode: screen;
+                animation: pillarGlow 18s ease-in-out infinite;
+        }
+        .pillar-card__pulse {
+                background: linear-gradient(120deg, rgba(255, 255, 255, 0.18), rgba(255, 255, 255, 0));
+                transform: translate3d(-40%, -40%, 0) rotate(12deg);
                 opacity: 0;
-                transition: opacity 0.3s ease;
+                transition: opacity 0.45s ease, transform 0.45s ease;
         }
-        .pillars article:hover {
-                transform: translateY(-6px);
-                box-shadow: 0 28px 48px rgba(var(--black), 0.18);
+        .pillar-card::after {
+                content: "";
+                position: absolute;
+                inset: 18px;
+                border-radius: inherit;
+                border: 1px solid rgba(255, 255, 255, 0.25);
+                opacity: 0.5;
+                pointer-events: none;
+                transition: opacity 0.35s ease, transform 0.35s ease;
         }
-        .pillars article:hover::before {
-                opacity: 1;
+        .pillar-card:hover,
+        .pillar-card:focus-within {
+                transform: translateY(-8px) scale(1.01);
+                box-shadow: 0 36px 70px rgba(15, 23, 42, 0.28);
+                border-color: rgba(var(--pillar-secondary), 0.5);
         }
-        .pillars h3 {
-                margin-bottom: 0.65rem;
+        .pillar-card:hover .pillar-card__pulse,
+        .pillar-card:focus-within .pillar-card__pulse {
+                opacity: 0.75;
+                transform: translate3d(0, 0, 0) rotate(0deg);
+        }
+        .pillar-card:hover::after,
+        .pillar-card:focus-within::after {
+                opacity: 0.85;
+                transform: scale(0.98);
+        }
+        .pillar-card--adversary {
+                --pillar-primary: 129, 140, 248;
+                --pillar-secondary: 56, 189, 248;
+        }
+        .pillar-card--detect {
+                --pillar-primary: 16, 185, 129;
+                --pillar-secondary: 14, 165, 233;
+        }
+        .pillar-card--educate {
+                --pillar-primary: 244, 114, 182;
+                --pillar-secondary: 59, 130, 246;
+        }
+        @keyframes pillarGlow {
+                0%,
+                100% {
+                        transform: translate3d(0, 0, 0) scale(1);
+                }
+                40% {
+                        transform: translate3d(6px, -4px, 0) scale(1.03);
+                }
+                70% {
+                        transform: translate3d(-8px, 6px, 0) scale(1.02);
+                }
         }
         .highlights ul {
                 list-style: none;
@@ -317,16 +409,26 @@ import { SITE_DESCRIPTION, SITE_TITLE } from '../consts';
                 animation: float 16s ease-in-out infinite;
                 opacity: 0.7;
         }
-        html[data-theme="dark"] .pillars article {
-                background: rgba(var(--surface-rgb), 0.9);
-                border-color: rgba(148, 163, 184, 0.18);
-                box-shadow: 0 16px 32px rgba(2, 6, 23, 0.65);
+        html[data-theme="dark"] .pillar-card {
+                background: linear-gradient(135deg, rgba(var(--pillar-primary), 0.18), rgba(var(--pillar-secondary), 0.2));
+                border-color: rgba(var(--pillar-secondary), 0.55);
+                box-shadow: 0 28px 56px rgba(2, 6, 23, 0.65);
         }
-        html[data-theme="dark"] .pillars article:hover {
-                box-shadow: 0 28px 48px rgba(2, 6, 23, 0.72);
+        html[data-theme="dark"] .pillar-card::after {
+                border-color: rgba(255, 255, 255, 0.18);
         }
-        html[data-theme="dark"] .pillars article::before {
-                background: linear-gradient(135deg, rgba(129, 140, 248, 0.16), rgba(16, 185, 129, 0.16));
+        html[data-theme="dark"] .pillar-card__pulse {
+                background: linear-gradient(120deg, rgba(255, 255, 255, 0.25), rgba(255, 255, 255, 0));
+        }
+        html[data-theme="dark"] .pillar-card:hover,
+        html[data-theme="dark"] .pillar-card:focus-within {
+                box-shadow: 0 42px 88px rgba(2, 6, 23, 0.72);
+        }
+        html[data-theme="dark"] .pillar-subhead {
+                color: rgba(var(--pillar-secondary), 0.9);
+        }
+        html[data-theme="dark"] .pillar-card p {
+                color: rgba(226, 232, 240, 0.85);
         }
         html[data-theme="dark"] .next {
                 background: rgba(var(--surface-rgb), 0.9);

--- a/src/pages/writeups/index.astro
+++ b/src/pages/writeups/index.astro
@@ -54,9 +54,11 @@ const pageTitle = "Writeups | " + SITE_TITLE;
                                 </p>
                         </header>
 
-                        <section class="grid">
+                        <section class="writeups-grid" data-animate="stagger">
                                 {writeups.map((entry) => (
                                         <article class="card">
+                                                <span class="card-orbit" aria-hidden="true"></span>
+                                                <span class="card-aurora" aria-hidden="true"></span>
                                                 <a class="card-link" href={`/writeups/${entry.slug}/`}>
                                                         <div class="card-sheen" aria-hidden="true"></div>
                                                         {entry.heroImage && (
@@ -69,22 +71,26 @@ const pageTitle = "Writeups | " + SITE_TITLE;
                                                                                 <p class="updated">Updated {entry.updatedDate.toLocaleDateString()}</p>
                                                                         )}
                                                                 </div>
-                                                                <h2>{entry.title}</h2>
-                                                                <p class="summary">{entry.summary}</p>
-                                                                {entry.tools.length > 0 && (
-                                                                        <ul class="tools" aria-label="Tooling">
-                                                                                {entry.tools.map((tool) => (
-                                                                                        <li>{tool}</li>
-                                                                                ))}
-                                                                        </ul>
-                                                                )}
-                                                                {entry.tags.length > 0 && (
-                                                                        <ul class="tags" aria-label="Tags">
-                                                                                {entry.tags.map((tag) => (
-                                                                                        <li>{tag}</li>
-                                                                                ))}
-                                                                        </ul>
-                                                                )}
+                                                                <div class="meta-heading">
+                                                                        <h2>{entry.title}</h2>
+                                                                        <p class="summary">{entry.summary}</p>
+                                                                </div>
+                                                                <div class="meta-footer">
+                                                                        {entry.tools.length > 0 && (
+                                                                                <ul class="tools" aria-label="Tooling">
+                                                                                        {entry.tools.map((tool) => (
+                                                                                                <li>{tool}</li>
+                                                                                        ))}
+                                                                                </ul>
+                                                                        )}
+                                                                        {entry.tags.length > 0 && (
+                                                                                <ul class="tags" aria-label="Tags">
+                                                                                        {entry.tags.map((tag) => (
+                                                                                                <li>{tag}</li>
+                                                                                        ))}
+                                                                                </ul>
+                                                                        )}
+                                                                </div>
                                                         </div>
                                                 </a>
                                         </article>
@@ -153,42 +159,85 @@ const pageTitle = "Writeups | " + SITE_TITLE;
                 border-radius: 999px;
                 font-weight: 700;
         }
-        .grid {
+        .writeups-grid {
                 display: grid;
-                gap: 2.5rem;
-                grid-template-columns: repeat(auto-fit, minmax(340px, 1fr));
+                gap: 2.75rem;
+                grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
         }
         .card {
-                background: rgba(255, 255, 255, 0.9);
-                border-radius: 1.35rem;
-                box-shadow: 0 30px 60px rgba(15, 23, 42, 0.14);
-                overflow: hidden;
-                transition: transform 0.35s ease, box-shadow 0.35s ease;
+                --card-accent: 14 165 233;
                 position: relative;
-                isolation: isolate;
+                border-radius: 1.5rem;
+                overflow: hidden;
+                padding: 1px;
+                background: linear-gradient(135deg, rgba(var(--card-accent), 0.25), rgba(16, 185, 129, 0.2));
+                box-shadow: 0 34px 64px rgba(15, 23, 42, 0.16);
+                transition: transform 0.4s ease, box-shadow 0.4s ease;
+        }
+        .card:nth-child(3n + 1) {
+                --card-accent: 56 189 248;
+        }
+        .card:nth-child(3n + 2) {
+                --card-accent: 244 114 182;
+        }
+        .card:nth-child(3n + 3) {
+                --card-accent: 129 140 248;
         }
         .card-link {
-                display: block;
+                display: grid;
+                grid-template-rows: auto 1fr;
                 text-decoration: none;
                 color: inherit;
                 height: 100%;
+                background: rgba(255, 255, 255, 0.92);
+                border-radius: calc(1.5rem - 1px);
+                overflow: hidden;
                 position: relative;
+                isolation: isolate;
         }
-        .card:hover {
-                transform: translateY(-10px);
-                box-shadow: 0 40px 70px rgba(15, 23, 42, 0.2);
+        .card-orbit,
+        .card-aurora {
+                position: absolute;
+                inset: 0;
+                pointer-events: none;
+        }
+        .card-orbit {
+                border-radius: inherit;
+                background: radial-gradient(circle at top right, rgba(var(--card-accent), 0.4), transparent 65%),
+                        radial-gradient(circle at bottom left, rgba(16, 185, 129, 0.4), transparent 60%);
+                filter: blur(0px);
+                mix-blend-mode: screen;
+                opacity: 0.9;
+                animation: cardOrbit 24s ease-in-out infinite;
+        }
+        .card-aurora {
+                border-radius: inherit;
+                background: conic-gradient(from 120deg, rgba(255, 255, 255, 0.45), rgba(255, 255, 255, 0) 55%, rgba(255, 255, 255, 0.5));
+                transform: translate3d(-35%, -25%, 0) rotate(8deg);
+                opacity: 0;
+                transition: opacity 0.45s ease, transform 0.45s ease;
+        }
+        .card:hover,
+        .card:focus-within {
+                transform: translateY(-12px) scale(1.01);
+                box-shadow: 0 48px 92px rgba(15, 23, 42, 0.24);
+        }
+        .card:hover .card-aurora,
+        .card:focus-within .card-aurora {
+                opacity: 0.9;
+                transform: translate3d(0, 0, 0) rotate(0deg);
         }
         .hero {
                 width: 100%;
-                height: auto;
+                height: clamp(180px, 28vw, 230px);
                 object-fit: cover;
-                max-height: 220px;
+                border-bottom: 1px solid rgba(var(--card-accent), 0.2);
         }
         .meta {
-                padding: 1.85rem 1.75rem 1.75rem;
+                padding: clamp(1.85rem, 4vw, 2.15rem) clamp(1.6rem, 4vw, 2rem) clamp(1.85rem, 4vw, 2.15rem);
                 color: rgb(var(--gray-dark));
                 display: grid;
-                gap: 1.1rem;
+                gap: 1.35rem;
         }
         .posted {
                 margin: 0;
@@ -210,32 +259,59 @@ const pageTitle = "Writeups | " + SITE_TITLE;
                 gap: 0.75rem;
                 align-items: baseline;
         }
+        .meta-heading {
+                display: grid;
+                gap: 0.65rem;
+        }
+        .meta-heading h2 {
+                margin: 0;
+                font-size: clamp(1.35rem, 2.2vw, 1.55rem);
+                line-height: 1.3;
+        }
         .summary {
                 margin: 0;
-                color: rgba(var(--gray-dark), 0.9);
-                line-height: 1.6;
+                color: rgba(var(--gray-dark), 0.88);
+                line-height: 1.65;
+                display: -webkit-box;
+                -webkit-line-clamp: 4;
+                -webkit-box-orient: vertical;
+                overflow: hidden;
+                text-overflow: ellipsis;
+                max-width: 65ch;
         }
-	.tools,
-	.tags {
-		margin: 0;
-		padding: 0;
-		list-style: none;
-		display: flex;
-		flex-wrap: wrap;
-		gap: 0.5rem;
-	}
-	.tools li,
-	.tags li {
-		font-size: 0.85rem;
-		padding: 0.35rem 0.75rem;
-		border-radius: 999px;
-		background: rgba(var(--accent), 0.12);
-		color: var(--accent);
-		font-weight: 600;
-	}
+        .meta-footer {
+                display: grid;
+                gap: 0.85rem;
+        }
+        .tools,
+        .tags {
+                margin: 0;
+                padding: 0;
+                list-style: none;
+                display: flex;
+                flex-wrap: wrap;
+                gap: 0.5rem;
+        }
+        .tools li,
+        .tags li {
+                font-size: 0.85rem;
+                padding: 0.35rem 0.75rem;
+                border-radius: 999px;
+                background: rgba(var(--accent), 0.12);
+                color: var(--accent);
+                font-weight: 600;
+                display: inline-flex;
+                align-items: center;
+                transition: transform 0.3s ease, background 0.3s ease;
+        }
         .tags li {
                 background: rgba(var(--gray-light), 0.45);
                 color: rgb(var(--gray-dark));
+        }
+        .tools li:hover,
+        .tags li:hover {
+                transform: translateY(-2px);
+                background: rgba(var(--card-accent), 0.22);
         }
         .card-sheen {
                 position: absolute;
@@ -247,6 +323,71 @@ const pageTitle = "Writeups | " + SITE_TITLE;
         }
         .card:hover .card-sheen {
                 transform: translateX(120%);
+        }
+        .card-link:focus-visible {
+                outline: 3px solid rgba(var(--card-accent), 0.65);
+                outline-offset: 6px;
+        }
+        [data-animate] {
+                opacity: 0;
+                transform: translateY(26px);
+                transition: opacity 0.6s cubic-bezier(0.22, 1, 0.36, 1), transform 0.6s cubic-bezier(0.22, 1, 0.36, 1);
+        }
+        [data-animate].is-visible {
+                opacity: 1;
+                transform: translateY(0);
+        }
+        [data-animate="stagger"] > * {
+                opacity: 0;
+                transform: translateY(28px);
+                transition: opacity 0.65s cubic-bezier(0.22, 1, 0.36, 1), transform 0.65s cubic-bezier(0.22, 1, 0.36, 1);
+                transition-delay: calc(var(--stagger-index, 0) * 0.12s + 0.08s);
+        }
+        [data-animate="stagger"].is-visible > * {
+                opacity: 1;
+                transform: translateY(0);
+        }
+        @keyframes cardOrbit {
+                0%,
+                100% {
+                        transform: translate3d(0, 0, 0) scale(1);
+                }
+                40% {
+                        transform: translate3d(10px, -12px, 0) scale(1.04);
+                }
+                70% {
+                        transform: translate3d(-14px, 10px, 0) scale(1.02);
+                }
+        }
+        html[data-theme="dark"] .card {
+                background: linear-gradient(135deg, rgba(var(--card-accent), 0.4), rgba(14, 116, 144, 0.4));
+                box-shadow: 0 50px 110px rgba(2, 6, 23, 0.7);
+        }
+        html[data-theme="dark"] .card-link {
+                background: rgba(15, 23, 42, 0.92);
+                color: rgba(226, 232, 240, 0.92);
+        }
+        html[data-theme="dark"] .meta {
+                color: rgba(226, 232, 240, 0.9);
+        }
+        html[data-theme="dark"] .summary {
+                color: rgba(226, 232, 240, 0.82);
+        }
+        html[data-theme="dark"] .tools li {
+                background: rgba(var(--card-accent), 0.24);
+                color: rgb(226, 232, 240);
+        }
+        html[data-theme="dark"] .tags li {
+                background: rgba(148, 163, 184, 0.28);
+                color: rgb(226, 232, 240);
+        }
+        html[data-theme="dark"] .card-link:focus-visible {
+                outline-color: rgba(var(--card-accent), 0.85);
+        }
+        @media (max-width: 960px) {
+                .writeups-grid {
+                        grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+                }
         }
         @keyframes headerRibbonDrift {
                 0% {
@@ -268,3 +409,43 @@ const pageTitle = "Writeups | " + SITE_TITLE;
                 }
         }
 </style>
+<script is:inline>
+        const animatedWriteupElements = document.querySelectorAll('[data-animate]');
+        if (animatedWriteupElements.length) {
+                const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)');
+                if (prefersReducedMotion.matches) {
+                        animatedWriteupElements.forEach((element) => {
+                                if (element.dataset.animate === 'stagger') {
+                                        element.querySelectorAll(':scope > *').forEach((child) => {
+                                                child.style.removeProperty('opacity');
+                                                child.style.removeProperty('transform');
+                                        });
+                                }
+                                element.classList.add('is-visible');
+                        });
+                } else {
+                        animatedWriteupElements.forEach((element) => {
+                                if (element.dataset.animate === 'stagger') {
+                                        element.querySelectorAll(':scope > *').forEach((child, index) => {
+                                                child.style.setProperty('--stagger-index', index);
+                                        });
+                                }
+                        });
+                        const observer = new IntersectionObserver(
+                                (entries) => {
+                                        entries.forEach((entry) => {
+                                                if (entry.isIntersecting) {
+                                                        entry.target.classList.add('is-visible');
+                                                        observer.unobserve(entry.target);
+                                                }
+                                        });
+                                },
+                                {
+                                        threshold: 0.2,
+                                        rootMargin: '0px 0px -80px 0px',
+                                }
+                        );
+                        animatedWriteupElements.forEach((element) => observer.observe(element));
+                }
+        }
+</script>


### PR DESCRIPTION
## Summary
- restyled the home page focus areas with colorful gradient cards and hover/pulse animations
- redesigned the writeups listing with animated borders, clamped summaries, and reorganized metadata layout
- added scroll-triggered animation handling for the writeups grid to keep interactions consistent across pages

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68dfe2f27be8832d96e38123d737648a