### PR TITLE
Add shared viewport animations and polish writeups theme

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,4 +1,6 @@
 ---
+import ViewportAnimator from "./ViewportAnimator.astro";
+
 const today = new Date();
 ---
 
@@ -39,6 +41,7 @@ const today = new Date();
 		</a>
 	</div>
 </footer>
+<ViewportAnimator />
 <style>
 	footer {
 		padding: 2em 1em 6em 1em;

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,7 +1,8 @@
 ﻿---
+import { Image } from "astro:assets";
 import { SITE_TITLE } from "../consts";
 import HeaderLink from "./HeaderLink.astro";
-import mainLogoUrl from "../assets/main-logo.png";
+import mainLogo from "../assets/main-logo.png";
 ---
 
 <header>
@@ -9,7 +10,15 @@ import mainLogoUrl from "../assets/main-logo.png";
     <nav>
       <h2>
         <a href="/">
-          <img src={mainLogoUrl} alt="Logo" class="logo-img" />
+          <Image
+            src={mainLogo}
+            alt="Site logo"
+            class="logo-img"
+            width={mainLogo.width}
+            height={mainLogo.height}
+            loading="eager"
+            decoding="async"
+          />
           {SITE_TITLE}
         </a>
       </h2>
@@ -359,7 +368,10 @@ import mainLogoUrl from "../assets/main-logo.png";
   .logo-img {
     height: 40px; /* chỉnh lại theo nhu cầu */
     width: auto;
+    max-width: 160px;
+    display: block;
     border-radius: 8px; /* nếu muốn bo góc */
+    object-fit: contain;
   }
 </style>
 

--- a/src/components/ViewportAnimator.astro
+++ b/src/components/ViewportAnimator.astro
@@ -1,0 +1,85 @@
+---
+---
+<script is:inline>
+  (() => {
+    if (typeof window === "undefined") return;
+    if (window.__viewportAnimatorInitialized) return;
+    window.__viewportAnimatorInitialized = true;
+
+    let mediaQuery;
+
+    const init = () => {
+      const animatedElements = document.querySelectorAll("[data-animate]");
+      if (!animatedElements.length) {
+        return;
+      }
+
+      mediaQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
+
+      const showImmediately = () => {
+        animatedElements.forEach((element) => {
+          if (element.dataset.animate === "stagger") {
+            element.querySelectorAll(":scope > *").forEach((child) => {
+              child.style.removeProperty("opacity");
+              child.style.removeProperty("transform");
+            });
+          }
+          element.classList.add("is-visible");
+        });
+      };
+
+      if (mediaQuery.matches) {
+        showImmediately();
+        return;
+      }
+
+      animatedElements.forEach((element) => {
+        if (element.dataset.animate === "stagger") {
+          element.querySelectorAll(":scope > *").forEach((child, index) => {
+            child.style.setProperty("--stagger-index", String(index));
+          });
+        }
+      });
+
+      const observer = new IntersectionObserver(
+        (entries, obs) => {
+          entries.forEach((entry) => {
+            if (entry.isIntersecting) {
+              entry.target.classList.add("is-visible");
+              obs.unobserve(entry.target);
+            }
+          });
+        },
+        {
+          threshold: 0.18,
+          rootMargin: "0px 0px -80px 0px",
+        }
+      );
+
+      animatedElements.forEach((element) => observer.observe(element));
+    };
+
+    if (document.readyState === "loading") {
+      document.addEventListener("DOMContentLoaded", init, { once: true });
+    } else {
+      init();
+    }
+
+    const handlePreferenceChange = (event) => {
+      if (event.matches) {
+        document
+          .querySelectorAll("[data-animate]")
+          .forEach((element) => element.classList.add("is-visible"));
+      }
+    };
+
+    if (window.matchMedia) {
+      mediaQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
+      if (typeof mediaQuery.addEventListener === "function") {
+        mediaQuery.addEventListener("change", handlePreferenceChange);
+      } else if (typeof mediaQuery.addListener === "function") {
+        mediaQuery.addListener(handlePreferenceChange);
+      }
+    }
+  })();
+</script>

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -58,12 +58,12 @@ const { title, description, pubDate, updatedDate, heroImage } = Astro.props;
 	<body>
 		<Header />
 		<main>
-			<article>
-				<div class="hero-image">
-					{heroImage && <Image width={1020} height={510} src={heroImage} alt="" />}
-				</div>
-				<div class="prose">
-					<div class="title">
+                        <article>
+                                <div class="hero-image" data-animate>
+                                        {heroImage && <Image width={1020} height={510} src={heroImage} alt="" />}
+                                </div>
+                                <div class="prose" data-animate>
+                                        <div class="title" data-animate="stagger">
 						<div class="date">
 							<FormattedDate date={pubDate} />
 							{

--- a/src/layouts/WriteupPost.astro
+++ b/src/layouts/WriteupPost.astro
@@ -107,15 +107,15 @@ const { title, summary, pubDate, updatedDate, heroImage, tags = [], tools = [] }
 	<body>
 		<Header />
 		<main>
-			<article>
-				{heroImage && (
-					<div class="hero">
-						<img src={heroImage} alt={title} loading="lazy" />
-					</div>
-				)}
-				<div class="prose">
-					<div class="header-block">
-						<div class="meta">
+                        <article>
+                                {heroImage && (
+                                        <div class="hero" data-animate>
+                                                <img src={heroImage} alt={title} loading="lazy" />
+                                        </div>
+                                )}
+                                <div class="prose" data-animate>
+                                        <div class="header-block" data-animate="stagger">
+                                                <div class="meta">
 							<FormattedDate date={pubDate} />
 							{updatedDate && (
 								<span>Refreshed on <FormattedDate date={updatedDate} /></span>
@@ -124,8 +124,8 @@ const { title, summary, pubDate, updatedDate, heroImage, tags = [], tools = [] }
 						<h1>{title}</h1>
 						<p>{summary}</p>
 					</div>
-					{tools.length > 0 && (
-						<div class="details-panel" role="complementary">
+                                        {tools.length > 0 && (
+                                                <div class="details-panel" role="complementary" data-animate>
 							<h2>Tool Stack</h2>
 							<ul>
 								{tools.map((tool) => (
@@ -134,8 +134,8 @@ const { title, summary, pubDate, updatedDate, heroImage, tags = [], tools = [] }
 							</ul>
 						</div>
 					)}
-					{tags.length > 0 && (
-						<ul class="pills">
+                                        {tags.length > 0 && (
+                                                <ul class="pills" data-animate="stagger">
 							{tags.map((tag) => (
 								<li>{tag}</li>
 							))}

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -88,9 +88,9 @@ const posts = (await getCollection('blog')).sort(
 	</head>
 	<body>
 		<Header />
-		<main>
-			<section>
-				<ul>
+                <main>
+                        <section data-animate>
+                                <ul data-animate="stagger">
 					{
 						posts.map((post) => (
 							<li>

--- a/src/pages/experience.astro
+++ b/src/pages/experience.astro
@@ -13,8 +13,8 @@ const pageTitle = "Experience | " + SITE_TITLE;
 	</head>
 	<body>
 		<Header />
-		<main>
-			<header class="page-header">
+                <main>
+                        <header class="page-header" data-animate>
 				<h1>Experience</h1>
 				<p>
 					Snapshots from red teaming, incident response, and community work. Drop company logos in
@@ -23,7 +23,7 @@ const pageTitle = "Experience | " + SITE_TITLE;
 				</p>
 			</header>
 
-			<section class="timeline">
+                        <section class="timeline" data-animate="stagger">
 				<article class="role">
 					<div class="role-header">
 						<h2>Senior Offensive Security Engineer</h2>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -541,35 +541,6 @@ import { SITE_DESCRIPTION, SITE_TITLE } from "../consts";
     );
     opacity: 0.85;
   }
-  [data-animate] {
-    opacity: 0;
-    transform: translateY(28px);
-    transition:
-      opacity 0.65s cubic-bezier(0.22, 1, 0.36, 1),
-      transform 0.65s cubic-bezier(0.22, 1, 0.36, 1);
-  }
-  [data-animate].is-visible {
-    opacity: 1;
-    transform: translateY(0);
-  }
-  [data-animate="stagger"] > * {
-    opacity: 0;
-    transform: translateY(24px);
-    transition:
-      opacity 0.65s cubic-bezier(0.22, 1, 0.36, 1),
-      transform 0.65s cubic-bezier(0.22, 1, 0.36, 1);
-    transition-delay: calc(var(--stagger-index, 0) * 0.12s + 0.1s);
-  }
-  [data-animate="stagger"].is-visible > * {
-    opacity: 1;
-    transform: translateY(0);
-  }
-  [data-animate="pop"] {
-    transform: scale(0.92) translateY(32px);
-  }
-  [data-animate="pop"].is-visible {
-    transform: scale(1) translateY(0);
-  }
   @media (max-width: 1080px) {
     .hero {
       grid-template-columns: minmax(300px, 1fr) minmax(220px, 0.85fr);
@@ -600,45 +571,3 @@ import { SITE_DESCRIPTION, SITE_TITLE } from "../consts";
     }
   }
 </style>
-<script is:inline>
-  const animatedElements = document.querySelectorAll("[data-animate]");
-  if (animatedElements.length) {
-    const prefersReducedMotion = window.matchMedia(
-      "(prefers-reduced-motion: reduce)"
-    );
-    if (prefersReducedMotion.matches) {
-      animatedElements.forEach((element) => {
-        if (element.dataset.animate === "stagger") {
-          element.querySelectorAll(":scope > *").forEach((child) => {
-            child.style.removeProperty("opacity");
-            child.style.removeProperty("transform");
-          });
-        }
-        element.classList.add("is-visible");
-      });
-    } else {
-      animatedElements.forEach((element) => {
-        if (element.dataset.animate === "stagger") {
-          element.querySelectorAll(":scope > *").forEach((child, index) => {
-            child.style.setProperty("--stagger-index", index);
-          });
-        }
-      });
-      const observer = new IntersectionObserver(
-        (entries) => {
-          entries.forEach((entry) => {
-            if (entry.isIntersecting) {
-              entry.target.classList.add("is-visible");
-              observer.unobserve(entry.target);
-            }
-          });
-        },
-        {
-          threshold: 0.2,
-          rootMargin: "0px 0px -80px 0px",
-        }
-      );
-      animatedElements.forEach((element) => observer.observe(element));
-    }
-  }
-</script>

--- a/src/pages/projects.astro
+++ b/src/pages/projects.astro
@@ -14,7 +14,7 @@ const pageTitle = "Projects | " + SITE_TITLE;
   <body>
     <Header />
     <main class="page">
-      <section class="hero">
+      <section class="hero" data-animate>
         <div class="hero__content">
           <p class="hero__eyebrow">Security experiments & lab builds</p>
           <h1>Projects</h1>
@@ -25,8 +25,8 @@ const pageTitle = "Projects | " + SITE_TITLE;
         </div>
       </section>
 
-      <section class="projects-section">
-        <div class="projects">
+      <section class="projects-section" data-animate>
+        <div class="projects" data-animate="stagger">
           <article class="project-card">
             <div class="project-card__body">
               <h2>Internal Purple Team Lab</h2>

--- a/src/pages/writeups/index.astro
+++ b/src/pages/writeups/index.astro
@@ -42,7 +42,7 @@ const pageTitle = "Writeups | " + SITE_TITLE;
 	<body>
 		<Header />
                 <main>
-                        <header class="page-header">
+                        <header class="page-header" data-animate>
                                 <div class="page-heading">
                                         <span class="eyebrow">Investigation Library</span>
                                         <h1>Writeups</h1>
@@ -158,6 +158,24 @@ const pageTitle = "Writeups | " + SITE_TITLE;
                 padding: 0.4rem 0.8rem;
                 border-radius: 999px;
                 font-weight: 700;
+        }
+        html[data-theme="dark"] .page-header {
+                background: rgba(var(--surface-rgb), 0.92);
+                box-shadow: 0 40px 80px rgba(2, 6, 23, 0.55);
+        }
+        html[data-theme="dark"] .page-header::before {
+                opacity: 0.85;
+                background: linear-gradient(120deg, rgba(56, 189, 248, 0.18), rgba(129, 140, 248, 0.22));
+        }
+        html[data-theme="dark"] .page-header::after {
+                background: rgba(var(--surface-rgb), 0.75);
+        }
+        html[data-theme="dark"] .page-header p {
+                color: rgba(226, 232, 240, 0.88);
+        }
+        html[data-theme="dark"] .eyebrow {
+                background: rgba(var(--card-accent, 56 189 248), 0.26);
+                color: rgb(226, 232, 240);
         }
         .writeups-grid {
                 display: grid;
@@ -328,25 +346,6 @@ const pageTitle = "Writeups | " + SITE_TITLE;
                 outline: 3px solid rgba(var(--card-accent), 0.65);
                 outline-offset: 6px;
         }
-        [data-animate] {
-                opacity: 0;
-                transform: translateY(26px);
-                transition: opacity 0.6s cubic-bezier(0.22, 1, 0.36, 1), transform 0.6s cubic-bezier(0.22, 1, 0.36, 1);
-        }
-        [data-animate].is-visible {
-                opacity: 1;
-                transform: translateY(0);
-        }
-        [data-animate="stagger"] > * {
-                opacity: 0;
-                transform: translateY(28px);
-                transition: opacity 0.65s cubic-bezier(0.22, 1, 0.36, 1), transform 0.65s cubic-bezier(0.22, 1, 0.36, 1);
-                transition-delay: calc(var(--stagger-index, 0) * 0.12s + 0.08s);
-        }
-        [data-animate="stagger"].is-visible > * {
-                opacity: 1;
-                transform: translateY(0);
-        }
         @keyframes cardOrbit {
                 0%,
                 100% {
@@ -409,43 +408,3 @@ const pageTitle = "Writeups | " + SITE_TITLE;
                 }
         }
 </style>
-<script is:inline>
-        const animatedWriteupElements = document.querySelectorAll('[data-animate]');
-        if (animatedWriteupElements.length) {
-                const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)');
-                if (prefersReducedMotion.matches) {
-                        animatedWriteupElements.forEach((element) => {
-                                if (element.dataset.animate === 'stagger') {
-                                        element.querySelectorAll(':scope > *').forEach((child) => {
-                                                child.style.removeProperty('opacity');
-                                                child.style.removeProperty('transform');
-                                        });
-                                }
-                                element.classList.add('is-visible');
-                        });
-                } else {
-                        animatedWriteupElements.forEach((element) => {
-                                if (element.dataset.animate === 'stagger') {
-                                        element.querySelectorAll(':scope > *').forEach((child, index) => {
-                                                child.style.setProperty('--stagger-index', index);
-                                        });
-                                }
-                        });
-                        const observer = new IntersectionObserver(
-                                (entries) => {
-                                        entries.forEach((entry) => {
-                                                if (entry.isIntersecting) {
-                                                        entry.target.classList.add('is-visible');
-                                                        observer.unobserve(entry.target);
-                                                }
-                                        });
-                                },
-                                {
-                                        threshold: 0.2,
-                                        rootMargin: '0px 0px -80px 0px',
-                                }
-                        );
-                        animatedWriteupElements.forEach((element) => observer.observe(element));
-                }
-        }
-</script>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -160,15 +160,50 @@ hr {
 }
 
 .sr-only {
-	border: 0;
-	padding: 0;
-	margin: 0;
-	position: absolute !important;
-	height: 1px;
-	width: 1px;
-	overflow: hidden;
-	clip: rect(1px 1px 1px 1px);
-	clip: rect(1px, 1px, 1px, 1px);
-	clip-path: inset(50%);
-	white-space: nowrap;
+        border: 0;
+        padding: 0;
+        margin: 0;
+        position: absolute !important;
+        height: 1px;
+        width: 1px;
+        overflow: hidden;
+        clip: rect(1px 1px 1px 1px);
+        clip: rect(1px, 1px, 1px, 1px);
+        clip-path: inset(50%);
+        white-space: nowrap;
+}
+
+[data-animate] {
+        opacity: 0;
+        transform: translate3d(0, 28px, 0);
+        transition:
+                opacity 0.65s cubic-bezier(0.22, 1, 0.36, 1),
+                transform 0.65s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+[data-animate].is-visible {
+        opacity: 1;
+        transform: translate3d(0, 0, 0);
+}
+
+[data-animate="stagger"] > * {
+        opacity: 0;
+        transform: translate3d(0, 26px, 0);
+        transition:
+                opacity 0.65s cubic-bezier(0.22, 1, 0.36, 1),
+                transform 0.65s cubic-bezier(0.22, 1, 0.36, 1);
+        transition-delay: calc(var(--stagger-index, 0) * 0.12s + 0.08s);
+}
+
+[data-animate="stagger"].is-visible > * {
+        opacity: 1;
+        transform: translate3d(0, 0, 0);
+}
+
+[data-animate="pop"] {
+        transform: scale(0.92) translate3d(0, 32px, 0);
+}
+
+[data-animate="pop"].is-visible {
+        transform: scale(1) translate3d(0, 0, 0);
 }


### PR DESCRIPTION
## Summary
- convert the header logo to use Astro's image pipeline and tweak styling so the new branding asset renders consistently
- add a reusable viewport animation controller via the footer and wire data-animate triggers across project, experience, blog, and writeup views
- refresh writeup header styling for dark mode to keep hero cards and intro copy readable

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68dfec7c1fd4832d8f55d092b2bfc5c4